### PR TITLE
Make middleware thread safe for instance vars

### DIFF
--- a/lib/rack/vendor_accept_header.rb
+++ b/lib/rack/vendor_accept_header.rb
@@ -21,11 +21,24 @@ module Rack
     ##
     # Entry point for triggering this middleware layer
     #
-    # This conforms to the rack middleware standard. This method is also
-    # where the business logic exists for parsing out the components of
-    # the vendor HTTP Accept header.
+    # This conforms to the rack middleware standard. This method is
+    # strictly handling duping the rack middleware instance itself and
+    # calling the `_call` method to perform the actual work. This is
+    # done to make this rack middleware thread safe for instance
+    # variable interactions within this rack middleware.
 
     def call(env)
+      dup._call(env)
+    end
+
+    ##
+    # This the workhorse of the middleware
+    #
+    # This method is where the business logic exists for parsing out the
+    # components of the vendor HTTP Accept header and exposing them in
+    # the application layer.
+
+    def _call(env)
       parts = parse_accept_header(env)
       env['vnd_version'] = parts[:version]
       env['vnd_context'] = parts[:context]


### PR DESCRIPTION
Why you made the change:

I did this so that we could use instance variables safely with Puma or
other threaded rack app servers.

How the change addresses the need:

Having the `call` method first `dup` the instance of the middleware
creates a shallow copying (meaning all its instance variables are
coppied) of the middleware. This is important because next it calls
`_call` on the dup. This makes it so that any alteration of instance
variables that happen within a request (and a thread) or scoped to the
copy not the original instance which is referenced when creating new
threads.